### PR TITLE
Update for PsN 4.7.0, extend build to include threads and updating the NONMEM license

### DIFF
--- a/nonmem/NONMEM.Dockerfile
+++ b/nonmem/NONMEM.Dockerfile
@@ -13,6 +13,7 @@ LABEL org.label-schema.name="osmosisfoundation/nonmem" \
 ARG NONMEM_MAJOR_VERSION=7
 ARG NONMEM_MINOR_VERSION=4
 ARG NONMEM_PATCH_VERSION=1
+ARG NONMEM_LICENSE_STRING=""
 ARG NONMEM_ZIP_PASS
 ENV NONMEM_URL=https://nonmem.iconplc.com/nonmem${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}/NONMEM${NONMEM_MAJOR_VERSION}.${NONMEM_MINOR_VERSION}.${NONMEM_PATCH_VERSION}.zip
 
@@ -38,6 +39,7 @@ RUN cd /tmp \
     && wget --no-verbose --no-check-certificate -O NONMEM.zip ${NONMEM_URL} \
     && unzip -P ${NONMEM_ZIP_PASS} NONMEM.zip \
     && cd /tmp/nm${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}CD \
+    && if [ -n "$NONMEM_LICENSE_STRING" ]; then mkdir -p /opt/nm/license; echo $NONMEM_LICENSE_STRING > /opt/nm/license/nonmem.lic ; fi \
     && bash SETUP${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION} \
                     /tmp/nm${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}CD \
        	            /opt/nm \

--- a/nonmem/build.sh
+++ b/nonmem/build.sh
@@ -3,15 +3,17 @@
 NONMEM_MAJOR_VERSION=7
 NONMEM_MINOR_VERSION=4
 NONMEM_PATCH_VERSION=1
+NONMEM_LICENSE_STRING=""
 
-USAGE=$(printf "Usage: %s: [-j major_version] [-n minor_version] [-t patch_version] zip_password\\\\n e.g. %s -j %s -n %s -t %s my_password\\\n or e.g. %s my_password" $0 $0 ${NONMEM_MAJOR_VERSION} ${NONMEM_MINOR_VERSION} ${NONMEM_PATCH_VERSION} $0)
+USAGE=$(printf "Usage: %s: [-j major_version] [-n minor_version] [-t patch_version] [-l license_string] zip_password\\\\n e.g. %s -j %s -n %s -t %s -l my_license my_password\\\n or e.g. %s my_password" $0 $0 ${NONMEM_MAJOR_VERSION} ${NONMEM_MINOR_VERSION} ${NONMEM_PATCH_VERSION} $0)
 
 
-while getopts ?j:n:t: name; do
+while getopts ?l:j:n:t: name; do
   case $name in
   j) NONMEM_MAJOR_VERSION=$OPTARG;;
   n) NONMEM_MINOR_VERSION=$OPTARG;;
   t) NONMEM_PATCH_VERSION=$OPTARG;;
+  l) NONMEM_LICENSE_STRING=$OPTARG;;
   ?)
      echo -e $USAGE
      exit 0;;
@@ -32,4 +34,5 @@ docker build -f NONMEM.Dockerfile \
   --build-arg NONMEM_MAJOR_VERSION=${NONMEM_MAJOR_VERSION} \
   --build-arg NONMEM_MINOR_VERSION=${NONMEM_MINOR_VERSION} \
   --build-arg NONMEM_PATCH_VERSION=${NONMEM_PATCH_VERSION} \
+  --build-arg NONMEM_LICENSE_STRING=${NONMEM_LICENSE_STRING} \
   --build-arg NONMEM_ZIP_PASS=$PASSWORD .

--- a/psn/Dockerfile
+++ b/psn/Dockerfile
@@ -72,11 +72,13 @@ RUN curl -SL https://github.com/UUPharmacometrics/PsN/releases/download/4.7.0/Ps
 	send \"\r\";" \
   && sed s/threads=5/threads=$NUM_THREADS/ /usr/local/share/perl/*/PsN_4*/psn.conf > psn.conf.tmp \
   && mv psn.conf.tmp /usr/local/share/perl/*/PsN_4*/psn.conf \
-  && if [ -n "$NONMEM_LICENSE_STRING" ]; then echo $NONMEM_LICENSE_STRING > /opt/nm/license/nonmem.lic ; fi \
-  && cd /usr/local/share/perl/*/PsN_test* \
-  && prove -r unit \
-  && prove -r system \
-  && rm -r /usr/local/share/perl/*/PsN_test* \
+  && if [ -n "$NONMEM_LICENSE_STRING" ]; then \
+      echo $NONMEM_LICENSE_STRING > /opt/nm/license/nonmem.lic \
+      && cd /usr/local/share/perl/*/PsN_test* \
+      && prove -r unit \
+      && prove -r system \
+      && rm -r /usr/local/share/perl/*/PsN_test* \
+  ; fi \
   && rm -rf /tmp/*
  
 WORKDIR /data

--- a/psn/Dockerfile
+++ b/psn/Dockerfile
@@ -12,11 +12,12 @@ LABEL org.label-schema.name="osmosisfoundation/psn" \
 
 # cpanm and PsN requirements
 RUN apt-get update \
- && apt-get -y --no-install-recommends install ca-certificates \
- gcc \
- build-essential \
- curl \
- expect \
+ && apt-get -y --no-install-recommends install \
+               ca-certificates \
+               gcc \
+               build-essential \
+               curl \
+               expect \
  && rm -fr /var/lib/apt/lists/* \
  && wget -qO- \
 	https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | \
@@ -29,39 +30,53 @@ RUN apt-get update \
 	File::Copy::Recursive \
 	Storable \
 	Moose \
-	MooseX::Params::Validate
+	MooseX::Params::Validate \
+	Test::Exception \
+	YAML::Tiny
 
+ARG NUM_THREADS=4
+ARG NONMEM_LICENSE_STRING=""
 WORKDIR /tmp
 
 # install PsN
-RUN curl -SL http://downloads.sourceforge.net/project/psn/PsN-4.6.0.tar.gz -o PsN-4.6.0.tar.gz \
- && tar -zxf /tmp/PsN-4.6.0.tar.gz \
+RUN curl -SL https://github.com/UUPharmacometrics/PsN/releases/download/4.7.0/PsN-4.7.0.tar.gz -o PsN-4.7.0.tar.gz \
+ && tar -zxf /tmp/PsN-4.7.0.tar.gz \
  && cd /tmp/PsN-Source \
- && expect -c "spawn perl setup.pl; \
-	expect -ex \"/usr/bin]:\"; \
+ && expect -c "set timeout { 2 exit }; \
+        spawn perl setup.pl; \
+	expect -ex \"PsN Utilities installation directory \[/usr/local/bin\]:\"; \
 	send \"\r\"; \
-	expect -ex \"/usr/bin/perl]:\"; \
+	expect -ex \"Path to perl binary used to run Utilities \[/usr/bin/perl\]:\"; \
 	send \"\r\"; \
-	expect -ex \"/usr/local/share/perl\"; \
+	expect -ex \"PsN Core and Toolkit installation directory \[/usr/local/share/perl\"; \
 	send \"\r\"; \
-	expect -ex \"check Perl modules\"; \
+	expect -ex \"Would you like this script to check Perl modules \[y/n\]?\"; \
 	send \"y\r\"; \
-	expect -ex \"are missing)\"; \
+	expect -ex \"Continue installing PsN (installing is possible even if modules are missing)\[y/n\]?\"; \
 	send \"y\r\"; \
-	expect -ex \"of your choice?\"; \
+	expect -ex \"Would you like to copy the PsN documentation to a file system location of your choice?\"; \
 	send \"n\r\"; \
-	expect -ex \"test library?\"; \
+	expect -ex \"Would you like to install the PsN test library?\"; \
 	send \"y\r\"; \
-	expect -ex \"/usr/local/share/perl\"; \
+	expect -ex \"PsN test library installation directory \[/usr/local/share/perl/\"; \
 	send \"\r\"; \
-	expect -ex \"configuration file?\"; \
+	expect -ex \"Would you like help to create a configuration file?\"; \
 	send \"y\r\"; \
-	expect -ex \"add another one\"; \
+        expect -ex \"Enter the *complete* path of the NM-installation directory:\"; \
+        send \"/opt/nm/\r\"; \
+	expect -ex \"Would you like to add another one\"; \
 	send \"n\r\"; \
-	expect -ex \"name nm730\"; \
-	send \"\r\"; \
+	expect -ex \"or press ENTER to use the name\"; \
+	send \"nm\r\"; \
 	expect -ex \"installation program.\"; \
 	send \"\r\";" \
+  && sed s/threads=5/threads=$NUM_THREADS/ /usr/local/share/perl/*/PsN_4*/psn.conf > psn.conf.tmp \
+  && mv psn.conf.tmp /usr/local/share/perl/*/PsN_4*/psn.conf \
+  && if [ -n "$NONMEM_LICENSE_STRING" ]; then echo $NONMEM_LICENSE_STRING > /opt/nm/license/nonmem.lic ; fi \
+  && cd /usr/local/share/perl/*/PsN_test* \
+  && prove -r unit \
+  && prove -r system \
+  && rm -r /usr/local/share/perl/*/PsN_test* \
   && rm -rf /tmp/*
  
 WORKDIR /data

--- a/psn/build.sh
+++ b/psn/build.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
-# TODO request/expect password as argument
+NUM_THREADS=4
+NONMEM_LICENSE_STRING=""
+USAGE=$(printf "Usage: %s: -l license_string [-h threads]" $0)
 
-docker build --tag psn .
+while getopts ?l:h: name; do
+    case $name in
+        l) NONMEM_LICENSE_STRING=$OPTARG;;
+        h) NUM_THREADS=$OPTARG;;
+        ?)
+	  echo -e $USAGE
+          exit 0;;
+    esac
+done
+
+docker build \
+       --tag osmosisfoundation/psn:4.7.0 --tag osmosisfoundation/psn \
+       --build-arg NONMEM_LICENSE_STRING=${NONMEM_LICENSE_STRING} \
+       --build-arg NUM_THREADS=${NUM_THREADS} .

--- a/psn/psnshell.sh
+++ b/psn/psnshell.sh
@@ -2,6 +2,6 @@
 
 # give me a bash prompt in container data directory to run psn commands
 
-docker run --rm -v $(pwd)/../license:/opt/nm730/license -v $(pwd)/../data:/data -it --entrypoint bash psn
+docker run --rm --user=$(id -u):$(id -g) -v $(pwd)/../license:/opt/nm/license -v $(pwd)/../data:/data -it --entrypoint bash osmosisfoundation/psn
 
 


### PR DESCRIPTION
This pull addresses #2, #3 (for PsN but not for NONMEM), #4, and #5.

Specifically:
* It updates to PsN 4.7.0 (also adding the YAML::Tiny module which is suggested by 4.7.0)
* It updates the way that PsN interfaces with NONMEM so that it is no longer version dependent (looking in /opt/nm).  This fails PsN autodetection of NONMEM installations, so the directory name has been provided in the expect scripts.
* It makes the expect scripts more specific and restrictive (this should be a good thing because accidental failures will be more quickly noticed).  In addition, it adds a failure to the scripts on timeout rather than a silent timeout.
* It updates the default number of threads for PsN to 4 (aligning with 1 license pack from Icon), and makes the default configurable by the user.
* It updates the build tagging to add "osmosisfoundation" and the PsN version number
* It updates `psnshell.sh` to run as the current user (so that files created belong to that user on exit) and point to the updated directory structure and docker container name.
* It requires the PsN tests to run successfully for the container to be generated (more on this below)

For requiring the tests, this may be controversial.  The main limiting factor is the NONMEM license being up to date.  Without a license, the tests will fail and the container won't be created.  It may be worth adding a "NO_TEST" option, but my preference is that any container should always be tested before being created so that invalid containers can't exist.