### PR TITLE
Add license handling for NONMEM

### DIFF
--- a/nonmem/NONMEM.Dockerfile
+++ b/nonmem/NONMEM.Dockerfile
@@ -13,6 +13,7 @@ LABEL org.label-schema.name="osmosisfoundation/nonmem" \
 ARG NONMEM_MAJOR_VERSION=7
 ARG NONMEM_MINOR_VERSION=4
 ARG NONMEM_PATCH_VERSION=1
+ARG NONMEM_LICENSE_STRING=""
 ARG NONMEM_ZIP_PASS
 ENV NONMEM_URL=https://nonmem.iconplc.com/nonmem${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}/NONMEM${NONMEM_MAJOR_VERSION}.${NONMEM_MINOR_VERSION}.${NONMEM_PATCH_VERSION}.zip
 
@@ -38,6 +39,7 @@ RUN cd /tmp \
     && wget --no-verbose --no-check-certificate -O NONMEM.zip ${NONMEM_URL} \
     && unzip -P ${NONMEM_ZIP_PASS} NONMEM.zip \
     && cd /tmp/nm${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}CD \
+    && if [ -n "$NONMEM_LICENSE_STRING" ]; then mkdir -p /opt/nm/license; echo $NONMEM_LICENSE_STRING > /opt/nm/license/nonmem.lic ; fi \
     && bash SETUP${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION} \
                     /tmp/nm${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}CD \
        	            /opt/nm \

--- a/nonmem/build.sh
+++ b/nonmem/build.sh
@@ -3,15 +3,17 @@
 NONMEM_MAJOR_VERSION=7
 NONMEM_MINOR_VERSION=4
 NONMEM_PATCH_VERSION=1
+NONMEM_LICENSE_STRING=""
 
-USAGE=$(printf "Usage: %s: [-j major_version] [-n minor_version] [-t patch_version] zip_password\\\\n e.g. %s -j %s -n %s -t %s my_password\\\n or e.g. %s my_password" $0 $0 ${NONMEM_MAJOR_VERSION} ${NONMEM_MINOR_VERSION} ${NONMEM_PATCH_VERSION} $0)
+USAGE=$(printf "Usage: %s: [-j major_version] [-n minor_version] [-t patch_version] [-l license_string] zip_password\\\\n e.g. %s -j %s -n %s -t %s -l my_license my_password\\\n or e.g. %s my_password" $0 $0 ${NONMEM_MAJOR_VERSION} ${NONMEM_MINOR_VERSION} ${NONMEM_PATCH_VERSION} $0)
 
 
-while getopts ?j:n:t: name; do
+while getopts ?l:j:n:t: name; do
   case $name in
   j) NONMEM_MAJOR_VERSION=$OPTARG;;
   n) NONMEM_MINOR_VERSION=$OPTARG;;
   t) NONMEM_PATCH_VERSION=$OPTARG;;
+  l) NONMEM_LICENSE_STRING=$OPTARG;;
   ?)
      echo -e $USAGE
      exit 0;;
@@ -32,4 +34,5 @@ docker build -f NONMEM.Dockerfile \
   --build-arg NONMEM_MAJOR_VERSION=${NONMEM_MAJOR_VERSION} \
   --build-arg NONMEM_MINOR_VERSION=${NONMEM_MINOR_VERSION} \
   --build-arg NONMEM_PATCH_VERSION=${NONMEM_PATCH_VERSION} \
+  --build-arg NONMEM_LICENSE_STRING=${NONMEM_LICENSE_STRING} \
   --build-arg NONMEM_ZIP_PASS=$PASSWORD .


### PR DESCRIPTION
In combination with #6, this completes the fix for #3.

This PR includes the addition of a NONMEM license string to the container build.  It is not as restrictive as #6 because it doesn't require the tests to be run-- it just enables them if possible.